### PR TITLE
Correctly specify the main package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "travix-css-themes-polyfill",
   "version": "0.1.1",
   "description": "Travix CSS variables for themes polyfill",
-  "main": "src/index.js",
+  "main": "lib/index.js",
   "scripts": {
     "build": "uglifyjs --compress --mangle --output lib/index.js src/index.js",
     "test": "node test/index.spec.js",


### PR DESCRIPTION
Since the `src/index.js` file is being ignored by `.npmignore` we should specify `lib/index.js` as the main file (which is the one that is included in the package distributed by npm. This allows us to reference the package with cdn's like unpkg in a simpler way:

https://unpkg.com/travix-css-themes-polyfill