### PR TITLE
Changes the build task to make sure the 'lib' directory exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Travix CSS variables for themes polyfill",
   "main": "lib/index.js",
   "scripts": {
-    "build": "uglifyjs --compress --mangle --output lib/index.js src/index.js",
+    "build": "mkdir -p lib && uglifyjs --compress --mangle --output lib/index.js src/index.js",
     "test": "node test/index.spec.js",
     "lint": "eslint --color src/index.js"
   },


### PR DESCRIPTION
# What does this PR do:

* Changes the build task to make sure the `lib` directory exists. This solves the error below, that happens when the folder does not exist:

<img width="1074" alt="screen shot 2017-08-14 at 22 17 09" src="https://user-images.githubusercontent.com/1002056/29289845-56d09a5e-813e-11e7-8f76-0b37332b9421.png">

# Where should the reviewer start:

* Diffs